### PR TITLE
feat: 主题优化，增加 Bigfish 特性

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,13 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "bracketSpacing": true,
+  "overrides": [
+    {
+      "files": ".prettierrc",
+      "options": { "parser": "json" }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "repository": "umijs/docz-theme-umi",
   "scripts": {
+    "dev": "umi-lib build --esm babel --watch",
     "build": "umi-lib build --esm babel",
     "prepublishOnly": "np --no-cleanup --yolo --no-publish"
   },

--- a/src/components/shared/Search/index.tsx
+++ b/src/components/shared/Search/index.tsx
@@ -38,15 +38,23 @@ interface SearchProps {
   onSearch: (value: string) => void
 }
 
-export const Search: SFC<SearchProps> = ({ onSearch }) => (
-  <Wrapper>
-    <Icon />
-    <Input
-      type="text"
-      placeholder="Search here..."
-      onChange={(ev: any) => {
-        onSearch && onSearch(ev.target.value)
-      }}
-    />
-  </Wrapper>
-)
+export const Search: SFC<SearchProps> = ({ onSearch }) => {
+  const browserLanguage: string = window.navigator.language
+  let placeholder: string = 'Search here...'
+  if (browserLanguage === 'zh-CN') {
+    placeholder = '在组件库中搜索...'
+  }
+
+  return (
+    <Wrapper>
+      <Icon />
+      <Input
+        type="text"
+        placeholder={placeholder}
+        onChange={(ev: any) => {
+          onSearch && onSearch(ev.target.value)
+        }}
+      />
+    </Wrapper>
+  )
+}

--- a/src/components/shared/Sidebar/index.tsx
+++ b/src/components/shared/Sidebar/index.tsx
@@ -92,6 +92,18 @@ const FooterLink = styled.a`
   margin-left: 5px;
 `
 
+const BuiltWithLink = styled.a`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`
+
+const BuiltWithLogo = styled.img`
+  width: 14px;
+  height: 14px;
+  margin-right: 4px;
+`
+
 const FooterLogo = styled(Docz)<{ width: number }>`
   fill: ${sidebarText};
 `
@@ -123,6 +135,12 @@ export const Sidebar: SFC = () => {
   const isDesktop = windowSize.outerWidth >= breakpoints.desktop
   const prevIsDesktop = usePrevious(isDesktop)
 
+  const browserLanguage: string = window.navigator.language
+  let emptyPlaceholder = 'No documents found.'
+  if (browserLanguage === 'zh-CN') {
+    emptyPlaceholder = '未找到相应组件'
+  }
+
   useEffect(() => {
     if (!hidden && !prevIsDesktop && isDesktop) {
       setHidden(true)
@@ -145,13 +163,11 @@ export const Sidebar: SFC = () => {
 
   const builtWith = process.env.BIGFISH_VERSION
     ? [
-      'Bigfish',
-      'https://bigfish-pre.antfin-inc.com/',
-    ]
-    : [
-      'umi-library',
-      'https://github.com/umijs/umi/tree/master/packages/umi-library',
-    ];
+        'Bigfish',
+        'https://bigfish-pre.antfin-inc.com/',
+        'https://gw-office.alipayobjects.com/basement_prod/c83c53ab-515e-43e2-85d0-4d0da16f11ef.svg',
+      ]
+    : ['umi-library', 'https://github.com/umijs/umi/tree/master/packages/umi-library', '']
 
   return (
     <Fragment>
@@ -162,7 +178,7 @@ export const Sidebar: SFC = () => {
           <Search onSearch={setQuery} />
 
           {menus && menus.length === 0 ? (
-            <Empty>No documents found.</Empty>
+            <Empty>{emptyPlaceholder}</Empty>
           ) : (
             <Menus>
               {menus &&
@@ -179,7 +195,10 @@ export const Sidebar: SFC = () => {
           <Footer>
             Built with
             <span>&nbsp;</span>
-            <a href={builtWith[1]} target="_blank">{builtWith[0]}</a>
+            <BuiltWithLink href={builtWith[1]} target="_blank">
+              {builtWith[2] ? <BuiltWithLogo src={builtWith[2]} /> : null}
+              {builtWith[0]}
+            </BuiltWithLink>
             <span>&nbsp;</span>
             and
             <FooterLink href="https://docz.site" target="_blank">

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,16 @@ import { Global } from './styles/global'
 import { config } from './config'
 import { ThemeProvider } from './utils/theme'
 
+if (process.env.BIGFISH_VERSION) {
+  // 更换 favicon 为 Bigfish logo
+  const link: HTMLLinkElement = document.querySelector("link[rel*='icon']") || document.createElement('link');
+  link.type = 'image/x-icon';
+  link.rel = 'icon';
+  link.href = "https://gw-office.alipayobjects.com/basement_prod/7e9551ab-bbaf-48fc-9253-9470e6593d2f.png";
+  const head = document.getElementsByTagName('head')[0]
+  head.insertBefore(link, head.firstChild);
+}
+
 const Theme: SFC = ({ children }) => (
   <ThemeProvider>
     <Global />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ if (process.env.BIGFISH_VERSION) {
   const link: HTMLLinkElement = document.querySelector("link[rel*='icon']") || document.createElement('link');
   link.type = 'image/x-icon';
   link.rel = 'icon';
-  link.href = "https://gw-office.alipayobjects.com/basement_prod/7e9551ab-bbaf-48fc-9253-9470e6593d2f.png";
+  link.href = "https://gw-office.alipayobjects.com/basement_prod/c83c53ab-515e-43e2-85d0-4d0da16f11ef.svg";
   const head = document.getElementsByTagName('head')[0]
   head.insertBefore(link, head.firstChild);
 }

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -3,8 +3,6 @@ import { get } from '@utils/theme'
 
 export const Global = createGlobalStyle`
   @import url('https://unpkg.com/codemirror@5.42.0/lib/codemirror.css');
-  @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600');
-  @import url('https://fonts.googleapis.com/css?family=Inconsolata');
 
   .icon-link {
     display: none;


### PR DESCRIPTION
- [x] 侧边栏需要有中文支持。根据浏览器语言修改左侧的一些默认文案。
- [x] 侧边栏底部改成 Built with Bigfish（带 logo）。
- [x] 右边支持标题，现在都是『代码演示』。右侧的标题现在完全根据 mdx 的内容来，不会出现写死的标题
- [x] Favicon 换成 Bigfish logo 中的一个。

cc @afc163