### PR TITLE
fix: remove menu title, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,46 @@ The umi theme of [docz](https://docz.site).
 
 ![](http://ww4.sinaimg.cn/large/006tNc79ly1g3yhyfm6rij31610u0neu.jpg)
 
+## Sorting your documents
+
+You can sort your documents by setting the `order` property in `*.mdx`.
+
+```mdx
+---
+name: BarComonent
+subName: Bar Component
+route: /bar
+order: 1
+---
+
+```
+
+Also, you can group your documents by setting the `menu` property.
+
+```mdx
+---
+name: FooComonent
+subName: Foo Component
+route: /foo
+menu: Basic Usage
+menuOrder: 1
+---
+
+```
+
+```mdx
+---
+name: AdvanceFooComonent
+subName: Advanced Foo Component
+route: /foo-advance
+menu: Advanced Usage
+menuOrder: 2
+---
+
+```
+
+By sorting multiple documents and menus, `order` is prior to `menuOrder`.
+
 ## Changing your logo
 
 Use your own logo by changing the `logo` property:

--- a/src/components/shared/Sidebar/CustomMenu.tsx
+++ b/src/components/shared/Sidebar/CustomMenu.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { MenuItem, Link, useDocs, Entry } from 'docz'
+import { Link, useDocs, Entry } from 'docz'
 import styled from 'styled-components'
 
 const MenuContainer = styled.div`
@@ -10,14 +10,7 @@ const MenuContainer = styled.div`
   flex: 1;
 `
 
-const MenuTitle = styled.div`
-  color: rgba(0, 0, 0, 0.85);
-  font-weight: 500;
-  font-size: 14px;
-`
-
 const Menu = styled.div`
-  margin-top: 24px;
   width: 100%;
 `
 
@@ -103,7 +96,6 @@ const CustomMenu: React.SFC<CustomMenuProps> = ({ query }) => {
 
   return (
     <MenuContainer>
-      <MenuTitle>Components</MenuTitle>
       <Menu>
         {docsArrangedInMenu &&
           docsArrangedInMenu.map((item: ArrangedDoc) =>


### PR DESCRIPTION
1. 补充了关于 menu / order / menuOrder 的配置说明
2. 去除了菜单栏顶部的 Components 标题