### PR TITLE
fix: 修复 CodeMirror 有时白屏的问题

### DIFF
--- a/src/components/ui/CodeMirror/index.tsx
+++ b/src/components/ui/CodeMirror/index.tsx
@@ -17,6 +17,7 @@ import 'codemirror/mode/css/css'
 import 'codemirror/addon/edit/matchbrackets'
 import 'codemirror/addon/edit/closetag'
 import 'codemirror/addon/fold/xml-fold'
+import 'codemirror/lib/codemirror.css';
 
 const Scrollbar = styled(PerfectScrollbar)`
   overflow: auto;
@@ -108,7 +109,7 @@ const CodeMirror: SFC<any> = props => {
 
       // Don't refresh if no height (CodeMirror is not visible) or
       // Don't refresh if same height
-      if (hasNoHeight || previousEditor === currentHeight) return
+      if (hasNoHeight || previousEditor.current === currentHeight) return
       refreshCodeMirror()
       previousEditor.current = editor.current.getScrollInfo().height || 0
     })
@@ -117,12 +118,12 @@ const CodeMirror: SFC<any> = props => {
   useEffect(() => {
     forceUpdateCodeMirror()
     return () => clearForceUpdateCodeMirror()
-  }, [])
+  }, [previousEditor.current])
 
   return (
     <React.Fragment>
       <ScrollbarStyles />
-      <Scrollbar option={scrollbarOpts} linesToScroll={linesToScroll}>
+      <Scrollbar options={scrollbarOpts} linesToScroll={linesToScroll}>
         <EditorStyled {...editorProps} />
       </Scrollbar>
     </React.Fragment>

--- a/src/components/ui/Page.tsx
+++ b/src/components/ui/Page.tsx
@@ -20,11 +20,11 @@ const Wrapper = styled.div`
   flex-direction: row;
 `
 
-export const Container = styled.div`
+export const Container = styled.div<{ fullpage?: boolean }>`
   box-sizing: border-box;
 
-  ${mq({
-    width: ['100%', '100%', '100%'],
+  ${props => mq({
+    width: props.fullpage ? ['100%', '100%', '100%'] : ['100%', 'calc(100% - 224px)', 'calc(100% - 224px)'],
     padding: ['20px', '0 24px 24px'],
   })}
 
@@ -119,7 +119,7 @@ export const Page: SFC<PageProps> = ({
       {!fullpage && <Sidebar />}
       <Wrapper>
         {fullpage ? (
-          content
+          <Container fullpage>{content}</Container>
         ) : (
           <>
             <Container>{content}</Container>

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -2,8 +2,6 @@ import { createGlobalStyle } from 'styled-components'
 import { get } from '@utils/theme'
 
 export const Global = createGlobalStyle`
-  @import url('https://unpkg.com/codemirror@5.42.0/lib/codemirror.css');
-
   .icon-link {
     display: none;
   }


### PR DESCRIPTION
从 `unpkg.com` 引入 `codemirror.css` 不够更稳定，浏览器强制刷新时会偶尔出现代码块白屏的现象